### PR TITLE
relay: tune libp2p relay::Config for production-grade workloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "boot-node"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "axum",
  "calimero-network-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boot-node"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Calimero Limited <info@calimero.network>"]
 edition = "2021"
 repository = "https://github.com/calimero-network/boot-node"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use std::net::Ipv4Addr;
+use std::time::Duration;
 
 use clap::Parser;
 use libp2p::futures::prelude::*;
@@ -15,7 +16,22 @@ mod http_service;
 
 const PROTOCOL_VERSION: &str = concat!("/", env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
 const CALIMERO_KAD_PROTO_NAME: StreamProtocol = StreamProtocol::new("/calimero/kad/1.0.0");
-const MAX_RELAY_CIRCUIT_BYTES: u64 = 100 << 20; // 100 MiB
+
+// libp2p `relay::Config::default()` ships with values sized for the test suite,
+// not production: 2-min circuits, 128 KiB per circuit, 16 total circuits, 4
+// circuits-per-peer, 128 total reservations, 4 reservations-per-peer. The
+// per-peer caps in particular bottleneck NAT-bound clients in any non-trivial
+// network. The overrides below size each relay node for ~200 active users
+// holding circuits to ~20 distinct peers each, with sync/state-delta streams
+// allowed to run for an hour and up to 1 GiB per circuit. Tune in lockstep
+// with the EC2 instance size — these settings expect at least `c7g.large`
+// (2 vCPU / 4 GiB) so the per-circuit state fits.
+const MAX_RELAY_CIRCUIT_BYTES: u64 = 1 << 30; // 1 GiB
+const MAX_RELAY_CIRCUIT_DURATION: Duration = Duration::from_secs(60 * 60); // 1 hour
+const MAX_RELAY_CIRCUITS: usize = 4096;
+const MAX_RELAY_CIRCUITS_PER_PEER: usize = 256;
+const MAX_RELAY_RESERVATIONS: usize = 2048;
+const MAX_RELAY_RESERVATIONS_PER_PEER: usize = 8;
 
 #[derive(NetworkBehaviour)]
 struct Behaviour {
@@ -132,6 +148,11 @@ async fn main() -> eyre::Result<()> {
                 relay: relay::Behaviour::new(keypair.public().to_peer_id(), {
                     let mut x = relay::Config::default();
                     x.max_circuit_bytes = MAX_RELAY_CIRCUIT_BYTES;
+                    x.max_circuit_duration = MAX_RELAY_CIRCUIT_DURATION;
+                    x.max_circuits = MAX_RELAY_CIRCUITS;
+                    x.max_circuits_per_peer = MAX_RELAY_CIRCUITS_PER_PEER;
+                    x.max_reservations = MAX_RELAY_RESERVATIONS;
+                    x.max_reservations_per_peer = MAX_RELAY_RESERVATIONS_PER_PEER;
                     x
                 }),
             }


### PR DESCRIPTION
## What

Bumps the libp2p `relay::Config` values on the boot-node from `Config::default()` (libp2p's test-suite-sized defaults) to values appropriate for serving a real multi-user network. Also bumps the crate version to `0.8.0` so the corresponding AMI/Terraform changes have a version to pin against.

## Why

The boot-node previously overrode only `max_circuit_bytes` (from libp2p's 128 KiB default to 100 MiB). Every other relay config field used libp2p's defaults, which are visible in real client logs as:

```
ReservationReqAccepted { 
  limit: Some(Limit { duration: Some(120s), data_in_bytes: Some(104857600) }) 
}
```

That `duration: 120s` is libp2p's default `max_circuit_duration` of 2 minutes leaking through, and it cuts off gossipsub mesh formation, state-delta sync, and any non-trivial application stream mid-flight. The 4-circuits-per-peer cap on the relay side further limits how many distinct remote peers any one client can reach through this relay concurrently.

Two NAT'd test peers in the recent connectivity reproducer could not complete `namespace-join` despite reaching the relay successfully — circuits were dying every 2 minutes before gossipsub mesh formation had time to populate.

## What's changed

| Field | libp2p default | New value | Rationale |
|---|---|---|---|
| `max_circuit_bytes` | 128 KiB | **1 GiB** (was 100 MiB) | Large state-delta transfers can complete without hitting the per-circuit data cap |
| `max_circuit_duration` | 2 min | **1 hour** | Sync and gossipsub mesh have time to stabilise; idle keepalive via ping keeps the QUIC connection warm |
| `max_circuits` | 16 | **4096** | Supports ~200 users × ~20 distinct circuits each; current devnet (~20 users) sits well under this with headroom |
| `max_circuits_per_peer` | 4 | **256** | Each user can reach up to 256 distinct remote peers through this relay |
| `max_reservations` | 128 | **2048** | Supports 2048 NAT-bound peers being reachable through this relay simultaneously |
| `max_reservations_per_peer` | 4 | **8** | Headroom for renewal-overlap edge cases; usually 1 reservation per peer is the steady state |
| `reservation_duration` | 1 h | unchanged | Already adequate; client renews well within window |

Reservation/circuit rate-limiters remain at libp2p defaults (30/peer/2min and 60/IP/min). Those weren't the binding constraint in the motivating failure-mode logs, and they're a sensible abuse-prevention floor — best left in place unless we see specific evidence they're throttling real flows.

## Operational notes

These caps assume the EC2 instance has enough memory to hold per-circuit state for the new totals. The current `c7g.medium` (1 vCPU / 2 GiB RAM) is tight at the new ceilings; at least `c7g.large` (2 vCPU / 4 GiB RAM) is recommended, and `c7g.xlarge` (4 vCPU / 8 GiB) provides comfortable headroom. The instance-size bump is tracked in [calimero-network/infrastructure#89](https://github.com/calimero-network/infrastructure/issues/89) alongside the fleet expansion to 3 boot-nodes in `eu-central-1`.

## Verification

`cargo check --release` (the same step CI runs) passes locally against the libp2p 0.56.0 / libp2p-relay 0.21.1 versions pinned in `Cargo.lock`. All six field names match the upstream `relay::Config` struct exactly — confirmed in `~/.cargo/registry/src/.../libp2p-relay-0.21.1/src/behaviour.rs`.

Field-name sanity check (libp2p-relay 0.21.1 `Default for Config`):
```rust
Config {
    max_reservations: 128,
    max_reservations_per_peer: 4,
    reservation_duration: Duration::from_secs(60 * 60),
    max_circuits: 16,
    max_circuits_per_peer: 4,
    max_circuit_duration: Duration::from_secs(2 * 60),  // ← the 120s we see in clients
    max_circuit_bytes: 1 << 17,
    ...
}
```

## Deployment path after merge

1. Tag `0.8.0`, push tag → release workflow builds new binary
2. `infrastructure/packer/aws/boot-node/` → rebuild AMI, tag as `boot-node-ubuntu-jammy-22.04-arm64-0.8.0`
3. `infrastructure/terraform/.../boot_node.tf` → bump `ami_name` and `instance_type`, optionally clone module for fleet
4. `terraform apply` → rolls new instance(s) with the updated config

Existing peer-id remains stable because it's keyed off the Secrets Manager entry, so clients holding the current bootstrap address continue to work after the cutover.

## Related

- Tracking issue (infra fleet + sizing): [calimero-network/infrastructure#89](https://github.com/calimero-network/infrastructure/issues/89)
- Client-side complement: [calimero-network/core#2438](https://github.com/calimero-network/core/issues/2438) — bulk-dial throttling, listen-addr filtering, AutoNATv2 candidate filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Raises libp2p relay limits (duration, bytes, circuit/reservation caps), which can significantly increase memory/CPU/network usage and affects connectivity behavior under load. Low code complexity, but mis-sizing could cause resource exhaustion or degraded relay stability.
> 
> **Overview**
> Updates the boot node’s libp2p relay configuration to be *production-sized* instead of relying on `relay::Config::default()` test-oriented limits. This increases per-circuit byte and duration limits and raises global/per-peer caps for circuits and reservations to better support many NAT’d clients and long-running sync streams.
> 
> Bumps the crate version from `0.7.0` to `0.8.0` (including `Cargo.lock`) to support pinning the release in deployment tooling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d9d59500d2cda86ba31f2019cdd92a3ba85011c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->