### PR TITLE
chore(release): bump version to 0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "boot-node"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "axum",
  "calimero-network-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boot-node"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Calimero Limited <info@calimero.network>"]
 edition = "2021"
 repository = "https://github.com/calimero-network/boot-node"


### PR DESCRIPTION
## Why

[#38](https://github.com/calimero-network/boot-node/pull/38) added a `docker/build-push-action` step to `release.yml` that publishes a multi-arch image to `ghcr.io/calimero-network/boot-node`. That step is downstream of the `release_exists == 'false'` guard in the `metadata` job, so it only runs when the Cargo-manifest version is new.

Master is still on `0.8.0`, which has an existing GitHub release, so the post-#38 push to master saw `release_exists == 'true'` and skipped the entire `Build and release` job — including the new buildx step. Result: GHCR has nothing under `calimero-network/boot-node` yet.

This PR bumps the version so the next push to master fires `release.yml` end-to-end and actually publishes the image tags:

* `ghcr.io/calimero-network/boot-node:0.8.1`
* `ghcr.io/calimero-network/boot-node:latest`
* `ghcr.io/calimero-network/boot-node:edge`

## What

* `Cargo.toml`: `0.8.0` → `0.8.1`
* `Cargo.lock`: matched

No code changes. The binary published as 0.8.1 will be byte-equivalent to 0.8.0 modulo the build-time version string baked into `--version`. Patch bump is the right semver shape for a release-only delta.

## Downstream

Once the `:edge` tag exists on GHCR, [merobox#256](https://github.com/calimero-network/merobox/pull/256)'s sibling task ships: drop the bundled `merobox/topology/images/boot-node/` Dockerfile and switch `BOOT_NODE_IMAGE_TAG` from `merobox/boot-node:local` to `ghcr.io/calimero-network/boot-node:edge`, mirroring how merobox already pulls `ghcr.io/calimero-network/merod`. That cleanup is what motivated the publish-and-pull pattern in #38 in the first place.

## Verification

After merge, `gh run list --workflow=release.yml --repo calimero-network/boot-node --limit 1` should show `Build and release` running (not skipped), and `gh api /orgs/calimero-network/packages/container/boot-node/versions` should return a non-empty list for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-metadata-only change with no application logic; risk is limited to triggering a new automated release and container publish.
> 
> **Overview**
> Bumps the **`boot-node`** crate from **`0.8.0`** to **`0.8.1`** in `Cargo.toml` and the matching `[[package]]` entry in `Cargo.lock`. There are no source or behavior changes beyond the build-time version string.
> 
> The intent is to trigger `release.yml` on the next push to `master`: the workflow only runs **Build and release** (including GHCR image publish) when that Cargo version does not already have a GitHub release, so a new patch version unblocks `ghcr.io/calimero-network/boot-node` tags such as `0.8.1`, `latest`, and `edge`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b66af97212f62b8154871456b445659b7cde2261. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->